### PR TITLE
DNSSEC Check Improvements

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,4 @@
 To Do List
 ==========
     1/ Integrate the DNSSEC Resolving into the flow: get rid of separate lookups
+    2/ Get rid of separate Resolvers once the bugs into DnsSecJava and DnsJava are solved

--- a/src/main/java/com/verisign/iot/discovery/commons/LookupContext.java
+++ b/src/main/java/com/verisign/iot/discovery/commons/LookupContext.java
@@ -19,6 +19,8 @@ public final class LookupContext implements Serializable
 	private static final long serialVersionUID = 448226124178324159L;
 	/** Resolver to be used during the lookup. */
 	private Resolver resolver;
+    /** Validating Resolver to be used during the DNSSEC check. */
+    private Resolver valResolver;
 	/** Instantiated @ Lookup} to be used. */
 	private Lookup lookup;
 	/** Fully Qualified Domain Name to lookup to (according to the other parameters). */
@@ -48,6 +50,17 @@ public final class LookupContext implements Serializable
 		this.resolver = resolver;
 	}
 
+    public Resolver getValResolver ()
+    {
+		return this.valResolver;
+	}
+
+
+	public void setValResolver ( Resolver resolver )
+    {
+		this.valResolver = resolver;
+	}
+    
 	public Lookup getLookup ()
     {
 		return this.lookup;

--- a/src/main/java/com/verisign/iot/discovery/utils/DnsUtil.java
+++ b/src/main/java/com/verisign/iot/discovery/utils/DnsUtil.java
@@ -42,6 +42,8 @@ public final class DnsUtil
     private static final String CHAIN_OF_TRUST = "chain of trust";
     private static final String NO_DATA = "nodata";
     private static final String NO_SIGNATURE = "missing signature";
+    private static final String MISSING_KEY = "missing dnskey rrset";
+    private static final String NSEC3_NO_DS = "nsec3s proved no ds";
 
 
     /**
@@ -126,10 +128,14 @@ public final class DnsUtil
                     outcome = StatusCode.RESOURCE_INSECURE_ERROR;
                 else if(reason.toString().toLowerCase().contains(NO_DATA))
                     outcome = StatusCode.NETWORK_ERROR;
-                else if(reason.toString().toLowerCase().contains(NO_SIGNATURE))
+                else if(reason.toString().toLowerCase().contains(NO_SIGNATURE) ||
+                        reason.toString().toLowerCase().contains(MISSING_KEY))
                     outcome = StatusCode.RESOLUTION_NAME_ERROR;
             }else if(dnsResponse.getRcode() == Rcode.NXDOMAIN) {
-                outcome = StatusCode.RESOLUTION_NAME_ERROR;
+                if(reason.toString().toLowerCase().contains(NSEC3_NO_DS))
+                    outcome = StatusCode.RESOURCE_INSECURE_ERROR;
+                else
+                    outcome = StatusCode.RESOLUTION_NAME_ERROR;
             }else if(dnsResponse.getRcode() == Rcode.NOERROR &&
                         !dnsResponse.getHeader().getFlag(Flags.AD)) {
                 outcome = StatusCode.RESOURCE_INSECURE_ERROR;

--- a/src/main/java/com/verisign/iot/discovery/utils/ExceptionsUtil.java
+++ b/src/main/java/com/verisign/iot/discovery/utils/ExceptionsUtil.java
@@ -73,7 +73,9 @@ public final class ExceptionsUtil
     {
         int cntr = 0;
         for(StatusCode status: trace.values())
-            if(status.equals(StatusCode.RESOLUTION_NAME_ERROR)) cntr += 1;
+            if(status.equals(StatusCode.RESOLUTION_NAME_ERROR) ||
+               status.equals(StatusCode.RESOLUTION_RR_TYPE_ERROR))  
+                cntr += 1;
 
         return (cntr == trace.size());
     }


### PR DESCRIPTION
Differentiated the Simple Resolvers from Validating ones to overcome the limitations of the used libraries: to be aligned with C, the DNSSEC is done independently from the resolution process.